### PR TITLE
fix: add repository field to package.json for npm provenance verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "print:eslint": "eslint --config ./eslint/examples/eslint.config.mjs --print-config ./eslint/examples/eslint.config.mjs",
     "format": "prettier --write ."
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kubosho/configs"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

Fix npm publish with provenance failing with E422.

## Changes

Added the `repository` field to `package.json`.

npm's sigstore provenance verification checks `package.json`'s `repository.url` against GitHub Actions build information. Since the field was missing, it was treated as an empty string, causing a mismatch with `https://github.com/kubosho/configs` and resulting in an E422 error.

## Test plan

Verify that the CI release job succeeds.