### PR TITLE
fix: replace hallucinated preset with :maintainLockFilesDisabled

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -7,7 +7,7 @@
 		":assignee(kubosho)",
 		":automergePatch",
 		":disableDependencyDashboard",
-		":disableLockFileMaintenance",
+		":maintainLockFilesDisabled",
 		":label(dependencies)"
 	],
 


### PR DESCRIPTION
## Summary

This PR replaces the hallucinated preset with the correct one, `:maintainLockFilesDisabled`, verified against the [Renovate default presets documentation](https://docs.renovatebot.com/presets-default/). It configures Renovate to update lock files only when `package.json` is modified, which keeps scheduled lockfile maintenance disabled as originally intended.